### PR TITLE
jmap_mail: convert empty filters and conditions to trivial nodes

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email-query-empty-filter-conds
+++ b/cassandane/tiny-tests/JMAPEmail/email-query-empty-filter-conds
@@ -1,0 +1,47 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_empty_filter_conds
+    :min_version_3_7 :needs_component_sieve :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    $self->make_message('test');
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                operator => 'NOT',
+                conditions => [{ }],
+            },
+        }, 'R0'],
+        ['Email/query', {
+            filter => {
+                operator => 'NOT',
+                conditions => [],
+            },
+        }, 'R1'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [{ }],
+            },
+        }, 'R2'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [],
+            },
+        }, 'R3'],
+    ], $using);
+
+    $self->assert_num_equals(0, scalar @{$res->[0][1]{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[2][1]{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[3][1]{ids}});
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2328,9 +2328,6 @@ HIDDEN void jmap_filter_parse(jmap_req_t *req, struct jmap_parser *parser,
             jmap_parser_invalid(parser, "operator");
         }
         arg = json_object_get(filter, "conditions");
-        if (!json_array_size(arg)) {
-            jmap_parser_invalid(parser, "conditions");
-        }
         json_array_foreach(arg, i, val) {
             jmap_parser_push_index(parser, "conditions", i, NULL);
             jmap_filter_parse(req, parser, val, unsupported, parse_condition, cond_rock, err);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2240,7 +2240,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
                                              ptrarray_t *search_attrs,
                                              strarray_t *perf_filters)
 {
-    search_expr_t *this, *e;
+    search_expr_t *this;
     json_t *val;
     const char *s;
     size_t i;
@@ -2251,32 +2251,56 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
     }
 
     if ((s = json_string_value(json_object_get(filter, "operator")))) {
-        enum search_op op = SEOP_UNKNOWN;
+        json_t *conditions = json_object_get(filter, "conditions");
+        int is_not = 0;
 
+        // Build operator node
         if (!strcmp("AND", s)) {
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_FALSE);
+            }
             this = search_expr_new(parent, SEOP_AND);
         } else if (!strcmp("OR", s)) {
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_FALSE);
+            }
             this = search_expr_new(parent, SEOP_OR);
         } else if (!strcmp("NOT", s)) {
-            op = SEOP_NOT;
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_TRUE);
+            }
             this = search_expr_new(parent, SEOP_AND);
-            /* zero properties evaluate to true */
-            search_expr_new(this, SEOP_TRUE);
+            is_not = 1;
         } else {
-            this = search_expr_new(parent, SEOP_UNKNOWN);
+            return search_expr_new(parent, SEOP_UNKNOWN);
         }
 
+        // Build operand nodes, skip empty conditions
+        json_array_foreach(conditions, i, val) {
+            if (json_object_size(val)) {
+                search_expr_t *e = is_not ? search_expr_new(this, SEOP_NOT) : this;
+                _email_buildsearchexpr(req, val, e, contactgroups, want_expunged,
+                        search_attrs, perf_filters);
+            }
+        }
 
-        json_array_foreach(json_object_get(filter, "conditions"), i, val) {
-            e = op != SEOP_UNKNOWN ? search_expr_new(this, op) : this;
-            _email_buildsearchexpr(req, val, e, contactgroups, want_expunged,
-                    search_attrs, perf_filters);
+        // Reduce empty operator nodes
+        if (!this->children) {
+            enum search_op op = is_not ? SEOP_FALSE : SEOP_TRUE;
+            if (parent) {
+                search_expr_detach(parent, this);
+            }
+            search_expr_free(this);
+            return search_expr_new(parent, op);
         }
     } else {
-        this = search_expr_new(parent, SEOP_AND);
+        if (!json_object_size(filter)) {
+            /* zero properties evaluate to true */
+            return search_expr_new(parent, SEOP_TRUE);
+        }
 
-        /* zero properties evaluate to true */
-        search_expr_new(this, SEOP_TRUE);
+        this = search_expr_new(parent, SEOP_AND);
+        search_expr_t *e;
 
         if ((s = json_string_value(json_object_get(filter, "after")))) {
             time_from_iso8601(s, &t);

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -842,16 +842,25 @@ static int _email_matchmime_evaluate(json_t *filter,
         int matches;
 
         if (!strcasecmpsafe(strop, "AND")) {
+            if (!json_array_size(conditions))
+                return 0;
+
             op = SEOP_AND;
             matches = 1;
         }
         else if (!strcasecmpsafe(strop, "OR")) {
+            if (!json_array_size(conditions))
+                return 0;
+
             op = SEOP_OR;
-            matches = json_array_size(conditions) == 0;
+            matches = 0;
         }
         else if (!strcasecmpsafe(strop, "NOT")) {
+            if (!json_array_size(conditions))
+                return 1;
+
             op = SEOP_NOT;
-            matches = json_array_size(conditions) != 0;
+            matches = 1;
         }
         else return 0;
 

--- a/imap/jmap_mail_query_parse.c
+++ b/imap/jmap_mail_query_parse.c
@@ -233,9 +233,6 @@ HIDDEN void jmap_email_filter_parse(json_t *filter,
             ctx->invalid_field("operator", ctx->rock);
         }
         json_t *jconds = json_object_get(filter, "conditions");
-        if (!json_array_size(jconds)) {
-            ctx->invalid_field("conditions", ctx->rock);
-        }
         size_t i;
         json_t *jcond;
         json_array_foreach(jconds, i, jcond) {


### PR DESCRIPTION
The JMAP spec does not require the "conditions" of FilterOperator
to have at least one member, but Cyrus rejected such operators
as invalid arguments. This patch allows empty conditions, and
evaluates as follows:

- an empty FilterCondition evaluates to true
- an AND or OR FilterOperator with no conditions evaluates to false
- a NOT FilterOperator with no conditions evaluates to true

Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>